### PR TITLE
add teleport-delay

### DIFF
--- a/src/main/java/it/heron/hpet/userpets/UserPet.java
+++ b/src/main/java/it/heron/hpet/userpets/UserPet.java
@@ -228,6 +228,12 @@ class UserPet {
     }
 
     protected void tick() {
+        int repeatDelay = Pet.instance.getConfig().getInt("teleport-delay", 2);
+        if (repeatDelay < 2){
+            // 2 is the minimum allowed value
+            repeatDelay = 2;
+        }
+
         this.taskID = Bukkit.getScheduler().scheduleSyncRepeatingTask(Pet.getInstance(), new Runnable() {
             @Override
             public void run() {
@@ -257,7 +263,7 @@ class UserPet {
                 step++;
                 animate();
             }
-        }, 2, 2);
+        }, 2, repeatDelay);
     }
 
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -59,3 +59,5 @@ mysql:
   port: 3306
   user: root
   password: password
+
+teleport-delay: 2


### PR DESCRIPTION
Added a configurable value for the teleport delay.
The constant teleporting every 2 ticks is very taxing on bigger servers.
This will allow server owners to fine-tune it for performance.